### PR TITLE
Add Yuki Okushi to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ of someone to add, feel free to open a PR.
 * [Diana (DianaNites)](https://github.com/sponsors/DianaNites)
 * [Carter Anderson (cart)](https://github.com/sponsors/cart)
 * [Lokathor (Lokathor)](https://github.com/sponsors/Lokathor)
+* [Yuki Okushi (JohnTitor)](https://github.com/sponsors/JohnTitor)
 
 ## Organizations
 


### PR DESCRIPTION
Yuko Okushi (JohnTitor) is active in several of the Rust teams, makes occasional contributions to [rust-lang/rust ](https://github.com/rust-lang/rust) and is lead maintainer of the [rust-lang/libc crate](https://github.com/rust-lang/libc) and the [Actix project](https://github.com/actix).